### PR TITLE
Adding watchlist sharing scripts

### DIFF
--- a/cb/watchlist_sharing/watchlist_exporter.py
+++ b/cb/watchlist_sharing/watchlist_exporter.py
@@ -1,0 +1,56 @@
+import cbapi
+import urlparse
+import urllib
+import json
+from optparse import OptionParser
+
+
+"""
+Exports watchlists into a sharable format for readying by a human and importable by a script
+"""
+
+def export(options):
+    cb = cbapi.CbApi(
+        options.cb_url,
+        token=options.cb_token,
+        ssl_verify=False)
+    watch_lists = cb.watchlist()
+    for watch_list in watch_lists:
+        seach_string = u''
+        url = urllib.unquote(options.cb_url + '?' + watch_list.get('search_query'))
+        parsed = urlparse.urlparse(url)
+        for parameter, value in urlparse.parse_qs(parsed.query).iteritems():
+            # make things like 'cb.q.netconn_count' turn into 'netconn_count:'
+            if 'cb.q.' in parameter:
+                search_param = parameter.replace('cb.q.', '')
+                seach_string += u' ' + search_param + u': ' + value[0]
+            # If it's "&q=" then we don't need to do any special formatting
+            if parameter == 'q':
+                seach_string += u' ' + value[0]
+        wl = {
+            "Name": watch_list.get('name'),
+            "URL": watch_list.get('search_query'),
+            "Type": watch_list.get('index_type'),
+            "Search String": seach_string.strip(),
+            "Description": "Please fill in if you intend to share this."
+        }
+        print(json.dumps(wl, indent=4))
+
+parser = OptionParser()
+parser.add_option("--cb_url",
+                  action="store",
+                  type="string",
+                  dest="cb_url",
+                  help="URL to CB server")
+parser.add_option("--cb_token",
+                  action="store",
+                  type="string",
+                  dest="cb_token",
+                  help="Token for CB server")
+(options, args) = parser.parse_args()
+
+if options.cb_url is None or options.cb_token is None:
+    parser.error('Must supply CB URL and token')
+
+if __name__ == "__main__":
+    export(options)

--- a/cb/watchlist_sharing/watchlist_exporter.py
+++ b/cb/watchlist_sharing/watchlist_exporter.py
@@ -2,55 +2,89 @@ import cbapi
 import urlparse
 import urllib
 import json
-from optparse import OptionParser
-
+import time
+from cbapi.util.cli_helpers import main_helper
 
 """
 Exports watchlists into a sharable format for readying by a human and importable by a script
 """
 
-def export(options):
-    cb = cbapi.CbApi(
-        options.cb_url,
-        token=options.cb_token,
-        ssl_verify=False)
-    watch_lists = cb.watchlist()
-    for watch_list in watch_lists:
-        seach_string = u''
-        url = urllib.unquote(options.cb_url + '?' + watch_list.get('search_query'))
-        parsed = urlparse.urlparse(url)
-        for parameter, value in urlparse.parse_qs(parsed.query).iteritems():
-            # make things like 'cb.q.netconn_count' turn into 'netconn_count:'
-            if 'cb.q.' in parameter:
-                search_param = parameter.replace('cb.q.', '')
-                seach_string += u' ' + search_param + u': ' + value[0]
-            # If it's "&q=" then we don't need to do any special formatting
-            if parameter == 'q':
-                seach_string += u' ' + value[0]
-        wl = {
-            "Name": watch_list.get('name'),
-            "URL": watch_list.get('search_query'),
-            "Type": watch_list.get('index_type'),
-            "Search String": seach_string.strip(),
-            "Description": "Please fill in if you intend to share this."
+class Export():
+    def __init__(self, cb, args):
+        self.cb = cb
+        self.args = args
+        self.watch_lists = []
+
+    def confirm(self, watch_list):
+        prompt = 'Export watchlist %s? y/n: ' % (watch_list.get('name'))
+        while True:
+            answer = raw_input(prompt)
+            if not answer:
+                return True
+            if answer not in ['y', 'Y', 'n', 'N']:
+                print 'Please enter y or n.'
+                continue
+            if answer in ['Y', 'y']:
+                return True
+            if answer in ['N', 'n']:
+                return False
+
+    def get_watchlists(self):
+        watch_lists = self.cb.watchlist()
+        for watch_list in watch_lists:
+            # Only export specific watchlists
+            if self.args.get('watchlists'):
+                if watch_list.get('name') not in self.args.get('watchlists').split(","):
+                    continue
+            # If we're being selective, ask the user
+            if self.args.get('selective_export'):
+                answer = self.confirm(watch_list)
+                if not answer:
+                    continue
+
+            search_string = u''
+            url = urllib.unquote(self.args.get('server_url') + '?' + watch_list.get('search_query'))
+            parsed = urlparse.urlparse(url)
+            for parameter, value in urlparse.parse_qs(parsed.query).iteritems():
+                 # make things like 'cb.q.netconn_count' turn into 'netconn_count:'
+                if 'cb.q.' in parameter:
+                    search_param = parameter.replace('cb.q.', '')
+                    search_string += u' ' + search_param + u': ' + value[0]
+                # If it's "&q=" then we don't need to do any special formatting
+                if parameter == 'q':
+                    search_string += u' ' + value[0]
+            wl = {
+                "Name": watch_list.get('name'),
+                "URL": watch_list.get('search_query'),
+                "Type": watch_list.get('index_type'),
+                "SearchString": search_string.strip(),
+                "Description": "Please fill in if you intend to share this."
+            }
+            self.watch_lists.append(wl)
+
+    def export_watchlists(self):
+        export = {
+            "Author": "Fill in author",
+            "ExportDate": time.strftime("%D %H:%M:%S"),
+            "ExportDescription": "Fill in description",
+            "Watchlists": self.watch_lists,
         }
-        print(json.dumps(wl, indent=4))
+        output = json.dumps(export, indent=4)
+        output_file = open(self.args.get('output_file'), 'w')
+        output_file.write(output)
+        print("-> Done exporting! <-")
 
-parser = OptionParser()
-parser.add_option("--cb_url",
-                  action="store",
-                  type="string",
-                  dest="cb_url",
-                  help="URL to CB server")
-parser.add_option("--cb_token",
-                  action="store",
-                  type="string",
-                  dest="cb_token",
-                  help="Token for CB server")
-(options, args) = parser.parse_args()
-
-if options.cb_url is None or options.cb_token is None:
-    parser.error('Must supply CB URL and token')
+def main(cb, args):
+    export = Export(cb, args)
+    export.get_watchlists()
+    export.export_watchlists()
 
 if __name__ == "__main__":
-    export(options)
+    selective_export = ("-m", "--selective", "store_true", False, "selective_export", "Select what watchlsits to export")
+    output_file = ("-f", "--file", "store", False, "output_file", "Select what file output is written to")
+    watchlists = ("-w", "--watchlists", "store", False, "watchlists", "Specific watchlist(s) to export. Can be comma separated.")
+    main_helper(
+        "Export watchlists into a sharable format",
+        main,
+        custom_required=[output_file],
+        custom_optional=[selective_export,watchlists])

--- a/cb/watchlist_sharing/watchlist_exporter.py
+++ b/cb/watchlist_sharing/watchlist_exporter.py
@@ -6,7 +6,7 @@ import time
 from cbapi.util.cli_helpers import main_helper
 
 """
-Exports watchlists into a sharable format for readying by a human and importable by a script
+Exports watchlists into a sharable format that's readable by a script or human
 """
 
 class Export():
@@ -46,7 +46,7 @@ class Export():
             url = urllib.unquote(self.args.get('server_url') + '?' + watch_list.get('search_query'))
             parsed = urlparse.urlparse(url)
             for parameter, value in urlparse.parse_qs(parsed.query).iteritems():
-                 # make things like 'cb.q.netconn_count' turn into 'netconn_count:'
+                # make things like 'cb.q.netconn_count' turn into 'netconn_count:'
                 if 'cb.q.' in parameter:
                     search_param = parameter.replace('cb.q.', '')
                     search_string += u' ' + search_param + u': ' + value[0]

--- a/cb/watchlist_sharing/watchlist_importer.py
+++ b/cb/watchlist_sharing/watchlist_importer.py
@@ -2,39 +2,54 @@ import os
 import logging
 import cbapi
 import json
-from optparse import OptionParser
 import urllib
+from cbapi.util.cli_helpers import main_helper
 
 """
 Imports the output from watchlist exporter
 """
 
 class ImportWatchlists():
-    def __init__(self, options):
-        self.options = options
-        self.cb = cbapi.CbApi(
-            options.cb_url,
-            token=options.cb_token,
-            ssl_verify=False)
+    def __init__(self, cb, args):
+        self.args = args
+        self.cb = cb
         self.watch_lists = []
+
+    def confirm(self, watch_list):
+        prompt = 'Export watchlist %s? y/n: ' % (watch_list.get('Name'))
+        while True:
+            answer = raw_input(prompt)
+            if not answer:
+                return True
+            if answer not in ['y', 'Y', 'n', 'N']:
+                print 'Please enter y or n.'
+                continue
+            if answer in ['Y', 'y']:
+                return True
+            if answer in ['N', 'n']:
+                return False
+
     def get_watchlists(self):
-        with open(self.options.wl_file) as f:
-            for line in f:
-                while True:
-                    try:
-                        watch_list = json.loads(line)
-                        self.watch_lists.append(watch_list)
-                        break
-                    except ValueError:
-                        # Not yet a complete JSON value
-                        line += next(f)
+        watchlist_file = open(self.args.get('input_file'), 'r')
+        data = watchlist_file.read()
+        json_data = json.loads(data)
+        for watch_list in json_data.get('Watchlists'):
+            # Only get that specific watchlist
+            if self.args.get('watchlists'):
+                if watch_list.get('Name') not in self.args.get('watchlists').split(","):
+                    continue
+            # If we're being selective, ask the user
+            if self.args.get('selective_import'):
+                answer = self.confirm(watch_list)
+                if not answer:
+                    continue
+            self.watch_lists.append(watch_list)
 
     def add_watchlists(self):
         for watch_list in self.watch_lists:
             wl_name = watch_list.get('Name')
             wl_type = watch_list.get('Type')
-            wl_url = watch_list.get('Search String').encode('utf-8')
-            wl_url = 'q=' + urllib.quote(wl_url)
+            wl_url = watch_list.get('SearchString').encode('utf-8')
             print("-> Adding watchlist %s" % wl_name)
             watchlist = self.cb.watchlist_add(
                 wl_type,
@@ -42,32 +57,18 @@ class ImportWatchlists():
                 wl_url)
             print("-> Watchlist added [id=%s]" % (watchlist['id']))
 
-parser = OptionParser()
-parser.add_option("--cb_url",
-                  action="store",
-                  type="string",
-                  dest="cb_url",
-                  help="URL to CB server")
-parser.add_option("--cb_token",
-                  action="store",
-                  type="string",
-                  dest="cb_token",
-                  help="Token for CB server")
-parser.add_option("--file",
-                  action="store",
-                  type="string",
-                  dest="wl_file",
-                  help="File with CB watchlists")
-(options, args) = parser.parse_args()
-
-if options.cb_url is None:
-    parser.error('Must supply CB URL')
-if options.cb_token is None:
-    parser.error('Must supply CB URL token')
-if options.wl_file is None:
-    parser.error('Must supply file')
-
-if __name__ == '__main__':
-    import_wl = ImportWatchlists(options)
+def main(cb, args):
+    import_wl = ImportWatchlists(cb, args)
     import_wl.get_watchlists()
     import_wl.add_watchlists()
+
+if __name__ == "__main__":
+    selective_import = ("-m", "--selective", "store_true", False, "selective_import", "Select what watchlsits to import")
+    input_file = ("-f", "--file", "store", False, "input_file", "Select what file holds watchlists")
+    watchlists = ("-w", "--watchlists", "store", False, "watchlists", "Specific watchlist(s) to import. Can be comma separated.")
+    main_helper(
+        "Imports watchlists from a sharable format",
+        main,
+        custom_required=[input_file],
+        custom_optional=[selective_import,watchlists])
+

--- a/cb/watchlist_sharing/watchlist_importer.py
+++ b/cb/watchlist_sharing/watchlist_importer.py
@@ -1,0 +1,73 @@
+import os
+import logging
+import cbapi
+import json
+from optparse import OptionParser
+import urllib
+
+"""
+Imports the output from watchlist exporter
+"""
+
+class ImportWatchlists():
+    def __init__(self, options):
+        self.options = options
+        self.cb = cbapi.CbApi(
+            options.cb_url,
+            token=options.cb_token,
+            ssl_verify=False)
+        self.watch_lists = []
+    def get_watchlists(self):
+        with open(self.options.wl_file) as f:
+            for line in f:
+                while True:
+                    try:
+                        watch_list = json.loads(line)
+                        self.watch_lists.append(watch_list)
+                        break
+                    except ValueError:
+                        # Not yet a complete JSON value
+                        line += next(f)
+
+    def add_watchlists(self):
+        for watch_list in self.watch_lists:
+            wl_name = watch_list.get('Name')
+            wl_type = watch_list.get('Type')
+            wl_url = watch_list.get('Search String').encode('utf-8')
+            wl_url = 'q=' + urllib.quote(wl_url)
+            print("-> Adding watchlist %s" % wl_name)
+            watchlist = self.cb.watchlist_add(
+                wl_type,
+                wl_name,
+                wl_url)
+            print("-> Watchlist added [id=%s]" % (watchlist['id']))
+
+parser = OptionParser()
+parser.add_option("--cb_url",
+                  action="store",
+                  type="string",
+                  dest="cb_url",
+                  help="URL to CB server")
+parser.add_option("--cb_token",
+                  action="store",
+                  type="string",
+                  dest="cb_token",
+                  help="Token for CB server")
+parser.add_option("--file",
+                  action="store",
+                  type="string",
+                  dest="wl_file",
+                  help="File with CB watchlists")
+(options, args) = parser.parse_args()
+
+if options.cb_url is None:
+    parser.error('Must supply CB URL')
+if options.cb_token is None:
+    parser.error('Must supply CB URL token')
+if options.wl_file is None:
+    parser.error('Must supply file')
+
+if __name__ == '__main__':
+    import_wl = ImportWatchlists(options)
+    import_wl.get_watchlists()
+    import_wl.add_watchlists()


### PR DESCRIPTION
These two scripts allow watch lists to be shared in a standard easy to read format. The exporter dumps out json, which can be shared around with a similar feel to a YARA rule. The importer can read a file full of these json objects and add the watchlists to your CB instance. 